### PR TITLE
Fix null-handling errors in DHCP report generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Fix `ConvertTo-TextYN` and `ConvertTo-EmptyToFiller` throwing on `$null` input by adding `[AllowNull()]` to the `$TEXT` parameter, so null values render as `--` instead of raising "Cannot process argument transformation on parameter 'TEXT'"
+- Fix `ConvertTo-HashToYN` iterating an undefined `$inObj` variable instead of its `$TEXT` parameter
+- Skip empty domain entries before calling `Get-ADDomain` in `Get-AbrADDHCPDomain` to avoid "Identity property on the argument is null or empty" errors
+
 ## [0.2.1] - 2025-09-26
 
 ### Added

--- a/Src/Private/Get-AbrADDHCPDomain.ps1
+++ b/Src/Private/Get-AbrADDHCPDomain.ps1
@@ -26,10 +26,10 @@ function Get-AbrADDHCPDomain {
         try {
             if ($InfoLevel.DHCP -ge 1 -and $DHCPinDomain ) {
                 foreach ($Domain in ($OrderedDomains.split(" "))) {
-                    if ($Domain -notin $Options.Exclude.Domains) {
+                    if ($Domain -and ($Domain -notin $Options.Exclude.Domains)) {
                         try {
                             $DomainInfo = Get-ADDomain $Domain -ErrorAction Stop
-                            if ($Domain) {
+                            if ($DomainInfo) {
                                 try {
                                     $DomainDHCPs = $DHCPinDomain | Where-Object { $_.DnsName.split(".", 2)[1] -eq $DomainInfo.DNSRoot } | Select-Object -ExpandProperty DnsName | Where-Object { $_ -notin $Options.Exclude.DCs }
                                     if ($DomainDHCPs) {

--- a/Src/Private/SharedUtilsFunctions.ps1
+++ b/Src/Private/SharedUtilsFunctions.ps1
@@ -20,6 +20,7 @@ function ConvertTo-TextYN {
             Position = 0,
             Mandatory)]
         [AllowEmptyString()]
+        [AllowNull()]
         [string] $TEXT
     )
 
@@ -88,6 +89,7 @@ function ConvertTo-EmptyToFiller {
             Position = 0,
             Mandatory)]
         [AllowEmptyString()]
+        [AllowNull()]
         [string]
         $TEXT
     )
@@ -163,7 +165,7 @@ function ConvertTo-HashToYN {
     )
 
     $result = [ordered] @{}
-    foreach ($i in $inObj.GetEnumerator()) {
+    foreach ($i in $TEXT.GetEnumerator()) {
         try {
             $result.add($i.Key, (ConvertTo-TextYN $i.Value))
         } catch {


### PR DESCRIPTION
## Summary

A DHCP report run against an environment with ~10 servers produced 700+ terminating errors in the verbose log while still completing. They trace to three null-handling defects.

## Details

**1. `ConvertTo-TextYN` / `ConvertTo-EmptyToFiller` throw on `$null`**

Both declare `[string] $TEXT` with `[AllowEmptyString()]` but not `[AllowNull()]`. A `$null` argument is rejected by the parameter binder before the body runs:

```
TerminatingError(ConvertTo-TextYN): "Cannot process argument transformation on parameter 'TEXT'. Cannot convert value to type System.String."
```

The existing `$Null { "--" }` switch case is unreachable as a result. DHCP properties that legitimately return null (e.g. failover `AutoStateTransition` / `EnableAuth`, option-definition `MultiValued`) hit this and leave blank cells in the report. The failover ones surface in the log as `(IPv4 Scope Failover Item)` warnings. Adding `[AllowNull()]` lets null reach the body and render as `--`.

**2. `ConvertTo-HashToYN` iterates the wrong variable**

The loop enumerates `$inObj`, which is never defined in the function; it should enumerate the `$TEXT` parameter. As written the conversion loop does nothing.

**3. `Get-AbrADDHCPDomain` calls `Get-ADDomain` before validating the domain**

`foreach ($Domain in ($OrderedDomains.split(" ")))` can yield an empty element, and `Get-ADDomain` is called before the `if ($Domain)` guard:

```
TerminatingError(Get-ADDomain): "Cannot validate argument on parameter 'Identity'. The Identity property on the argument is null or empty." (DHCP Servers Section)
```

Guarding `$Domain` in the outer `if` (and testing `$DomainInfo` afterwards) skips the empty entry.

## Changes

- `SharedUtilsFunctions.ps1` - add `[AllowNull()]` to `ConvertTo-TextYN` and `ConvertTo-EmptyToFiller`; fix `ConvertTo-HashToYN` to enumerate `$TEXT`
- `Get-AbrADDHCPDomain.ps1` - validate the domain value before `Get-ADDomain`, test `$DomainInfo` for the section guard
- `CHANGELOG.md` - Unreleased / Fixed entries

## Testing

`ConvertTo-TextYN` exercised against `$null`, `''`, `' '`, `'True'`, `'False'`, and arbitrary text - null/empty/space now return `--`, booleans return Yes/No, and no terminating error is raised. Both changed files parse cleanly.
